### PR TITLE
Feature/handle refresh token

### DIFF
--- a/src/messaging/classes/HttpClient.ts
+++ b/src/messaging/classes/HttpClient.ts
@@ -136,7 +136,7 @@ export abstract class HttpClient {
         ) {
             // increment auth token retry count
             this.authRetryCount++;
-            await setAuthTokenRetryCount(this.authRetryCount.toString());
+            await setAuthTokenRetryCount(this.authRetryCount);
 
             // retrieve auth credentials
             const authCredentials = await this.auth.getCredentials();

--- a/src/messaging/constants/Constants.ts
+++ b/src/messaging/constants/Constants.ts
@@ -15,6 +15,7 @@ export abstract class Constants {
     static readonly USER_AGENT: string = 'Telstra Messaging SDK/0.3.18';
     static readonly X_TELSTRA_AGENT_MEDIA_TYPE: string =
         'telstra.messaging.v2; param=full; format=json; lang=javascript';
+    static readonly authToken: string = 'SMyAEhIFsqXFQxlC9hyljz7m8kL4';
 
     static readonly ERRORS = {
         STORAGE_ERROR_GET: {

--- a/src/messaging/constants/Constants.ts
+++ b/src/messaging/constants/Constants.ts
@@ -15,7 +15,6 @@ export abstract class Constants {
     static readonly USER_AGENT: string = 'Telstra Messaging SDK/0.3.18';
     static readonly X_TELSTRA_AGENT_MEDIA_TYPE: string =
         'telstra.messaging.v2; param=full; format=json; lang=javascript';
-    static readonly authToken: string = 'SMyAEhIFsqXFQxlC9hyljz7m8kL4';
 
     static readonly ERRORS = {
         STORAGE_ERROR_GET: {


### PR DESCRIPTION
tests passed locally but not remotely on merge, fixed issue with string vs expected number.

``` PASS  test/src/messaging/classes/Message.spec.js
  Message
    healthCheck
      when the client makes a healthcheck call
        ✓ should pass (29ms)
    getNextUnreadReply
      when the client sends a valid request
        ✓ should pass (26ms)
    status
      when the client sends a valid [messageId] attribute
        ✓ should pass (7ms)
    send
      when the client sends valid required attributes
        ✓ should pass when [to] is a string having 10 chars (8ms)
        ✓ should pass when [to] is a string having 12 chars (6ms)
        ✓ should pass when [to] is an array of strings having 10 chars (5ms)
        ✓ should pass when [to] is an array of strings having 12 chars (6ms)
        ✓ should pass when [type] is string having value [sms] (6ms)
        ✓ should pass when [type] is string having value [mms] (5ms)
        ✓ should pass when [MMSContent] is an object with properties [type] and [payload] of type string (7ms)
        ✓ should pass when [MMSContent] is an object with properties [type], [filename] and [payload] of type string (6ms)
        ✓ should pass when [subject] is of type string and max length is less than 64 characters (5ms)
        ✓ should pass when [to] is an array of strings having 10 members (7ms)
      when the client sends invalid required attributes
        ✓ should fail and throw an assertion error when no object (12ms)
        ✓ should fail and throw an assertion error when object has no key:values (1ms)
        ✓ should fail and throw an assertion error when [to] is missing (1ms)
        ✓ should fail and throw an assertion error when [body] is missing (1ms)
        ✓ should fail and throw an assertion error when [to] is a number and [body] is missing (1ms)
        ✓ should fail and throw an assertion error when [to] is a number (1ms)
        ✓ should fail and throw an assertion error when [to] is an empty array (1ms)
        ✓ should fail and throw an assertion error when [to] is an array of numbers (1ms)
        ✓ should fail and throw an assertion error when [to] is an array of strings of length less than 10 (1ms)
        ✓ should fail and throw an assertion error when [to] is an array of strings of length greater than 12 (1ms)
        ✓ should fail and throw an assertion error when [to] is an array of strings having duplicates (1ms)
        ✓ should fail and throw an assertion error when [to] is an array of strings having more than 10 members (1ms)
        ✓ should fail and throw an assertion error when [to, body] are numbers (1ms)
        ✓ should fail and throw an assertion error when [body] is a number (1ms)
        ✓ should fail and throw an assertion error when [MMSContent] is not an array (1ms)
        ✓ should fail and throw an assertion error as the [type] property of [MMSContent] object is required field  (1ms)
        ✓ should fail and throw an assertion error when the [type] property of [MMSContent] object is not a string 
        ✓ should fail and throw an assertion error as the [type] property of [MMSContent] object is required a be a valid string  (1ms)
        ✓ should fail and throw an assertion error as the [payload] property of [MMSContent] object is required field  (4ms)
        ✓ should fail and throw an assertion error when the [payload] property of [MMSContent] object is not a string 
      when the client sends invalid optional attributes
        ✓ should pass with attr [type] as a string (7ms)
        ✓ should fail and throw an assertion error when [type] requires a string (1ms)
        ✓ should fail and throw an assertion error when [type] is a string
        ✓ should fail and throw an assertion error when [from] is a number (1ms)
        ✓ should pass when [from] is a string (4ms)
        ✓ should fail and throw an assertion error when [validity] is a string (1ms)
        ✓ should fail and throw an assertion error when [validity] is greater than 10080 (1ms)
        ✓ should fail and throw an assertion error when [validity] is less than 1 (1ms)
        ✓ should pass when [validity] is greater than 0 (5ms)
        ✓ should fail and throw an assertion error when [scheduledDelivery] is less than 1
        ✓ should pass when [scheduledDelivery] is greater than 0 (5ms)
        ✓ should fail and throw an assertion error when [notifyURL] is a number (1ms)
        ✓ should pass when [notifyURL] is a string (4ms)
        ✓ should fail and throw an assertion error when [replyRequest] is a number (1ms)
        ✓ should pass when [replyRequest] is a boolean (5ms)
        ✓ should fail and throw an assertion error when [priority] is a number (1ms)
        ✓ should pass when [priority] is a boolean (4ms)
        ✓ should fail and throw an assertion error when [receiptOff] is a number (1ms)
        ✓ should pass when [receiptOff] is a boolean (4ms)
        ✓ should fail and throw an assertion error when [userMsgRef] is a number
        ✓ should pass when [userMsgRef] is a string (5ms)
        ✓ should fail and throw an assertion error when [subject] is not a string (1ms)
        ✓ should fail and throw an assertion error when [subject] is a string greater than 64 characters (1ms)
        ✓ should fail and throw an assertion error when the [filename] property of [MMSContent] object is not a string 
    sendBulk
      when the client sends an object
        ✓ should pass with valid schema (7ms)
        ✓ should throw an assertion error when attr smsMulti is an array having attr(s) [to, body] as valid and business constraint [notifyURL] required where [receiptOff] is undefined or false  (1ms)
        ✓ should throw an assertion error when payload is missing (1ms)
        ✓ should throw an assertion error when payload is object without attributes
        ✓ should throw an assertion error when attr smsMulti is a number (1ms)
        ✓ should throw an assertion error when attr smsMulti is an empty array (1ms)
        ✓ should throw an assertion error when attr smsMulti is an array of numbers
        ✓ should throw an assertion error when attr smsMulti is an array having an empty object member (1ms)
        ✓ should throw an assertion error when attr smsMulti is an array having attr [to] as a number and attr [body] as a number (1ms)
        ✓ should throw an assertion error when attr smsMulti is an array having attr [to] as a number and attr [body] as a string
        ✓ should throw an assertion error when attr smsMulti is an array having attr [to] as a string and attr [body] as a number (1ms)
        ✓ should throw an assertion error when attr smsMulti is an array having attr [to] as a string and attr [body] as a number (1ms)
        ✓ should throw an assertion error when attr smsMulti is an array having attr [to] is less than 10
        ✓ should throw an assertion error when attr smsMulti is an array having attr [to] is greater than 12 (4ms)
```